### PR TITLE
Carousel View did not resize on rotation

### DIFF
--- a/txt/src/carouselView/dev/Shared.iOS/CarouselViewRenderer.cs
+++ b/txt/src/carouselView/dev/Shared.iOS/CarouselViewRenderer.cs
@@ -248,12 +248,13 @@ namespace Xamarin.Forms.Platform
 				return;
 
 			base.Control.ReloadData();
-			_lastBounds = Bounds;
 
 			var wasPortrait = _lastBounds.Height > _lastBounds.Width;
 			var nowPortrait = Bounds.Height > Bounds.Width;
 			if (wasPortrait != nowPortrait)
 				_controller.ScrollToPosition(_position, false);
+				
+			_lastBounds = Bounds;
 		}
 		public override SizeRequest GetDesiredSize(double widthConstraint, double heightConstraint)
 		{


### PR DESCRIPTION
Booleans wasPortait and nowportrait were alwasys false (and the same) moving the setting the previous bounds to below the rotation check allows them to be different and resize carousel
