### PR TITLE
fix crash on iOS 8 when entering-existing carousel caused by memory leak

### DIFF
--- a/txt/src/carouselView/dev/Shared.iOS/CarouselViewRenderer.cs
+++ b/txt/src/carouselView/dev/Shared.iOS/CarouselViewRenderer.cs
@@ -233,8 +233,14 @@ namespace Xamarin.Forms.Platform
 			if (disposing && !_disposed)
 			{
 				_disposed = true;
-				if (Element != null)
+				if (Element != null) {
 					((ICarouselViewController)Element).CollectionChanged -= OnCollectionChanged;
+					if(_controller != null) {
+						_controller.Dispose();
+					}
+					this.Control.Dispose();
+					this.Dispose();
+				}
 			}
 
 			base.Dispose(disposing);

--- a/txt/src/carouselView/dev/Shared.iOS/CarouselViewRenderer.cs
+++ b/txt/src/carouselView/dev/Shared.iOS/CarouselViewRenderer.cs
@@ -255,12 +255,13 @@ namespace Xamarin.Forms.Platform
 				return;
 
 			base.Control.ReloadData();
-			_lastBounds = Bounds;
 			
 			var wasPortrait = _lastBounds.Height > _lastBounds.Width;
 			var nowPortrait = Bounds.Height > Bounds.Width;
 			if (wasPortrait != nowPortrait)
 				_controller.ScrollToPosition(_position, false);
+
+			_lastBounds = Bounds;
 		}
 		public override SizeRequest GetDesiredSize(double widthConstraint, double heightConstraint)
 		{

--- a/txt/src/carouselView/dev/Shared.iOS/CarouselViewRenderer.cs
+++ b/txt/src/carouselView/dev/Shared.iOS/CarouselViewRenderer.cs
@@ -222,6 +222,7 @@ namespace Xamarin.Forms.Platform
 
 				// initialize properties
 				_position = Element.Position;
+				_controller.ReloadData(_position);
 
 				// hook up crud events
 				((ICarouselViewController)newElement).CollectionChanged += OnCollectionChanged;
@@ -255,7 +256,7 @@ namespace Xamarin.Forms.Platform
 
 			base.Control.ReloadData();
 			_lastBounds = Bounds;
-
+			
 			var wasPortrait = _lastBounds.Height > _lastBounds.Width;
 			var nowPortrait = Bounds.Height > Bounds.Width;
 			if (wasPortrait != nowPortrait)


### PR DESCRIPTION
I have in my app a carouselView with 4 images in it. On iOS 8.1 if I enter, exit and re-enter I get a crash. This doesn't happen on iOS10. Not tested on iOS9